### PR TITLE
Fix scheduler weekview

### DIFF
--- a/app/src/main/java/com/example/lambda/lambdaorganizer/ScheduleOverview.java
+++ b/app/src/main/java/com/example/lambda/lambdaorganizer/ScheduleOverview.java
@@ -17,6 +17,7 @@ import android.view.MenuInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.LinearLayout;
+import android.util.Log;
 
 import com.alamkanak.weekview.MonthLoader;
 import com.alamkanak.weekview.WeekView;
@@ -35,6 +36,7 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
     private int mWeekViewType = TYPE_THREE_DAY_VIEW;
     private WeekView mWeekView;
     private List<WeekViewEvent> mEvents;
+    private static final String TAG = "ScheduleOverview";
     protected SimpleDateFormat dateFormatter = new SimpleDateFormat("dd MMM yyyy");
 
     @Override
@@ -193,6 +195,19 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
     }
 
     /**
+     * Checks if two WeekViewEvent objects are equal.
+     * @param event1 The first WeekViewEvent.
+     * @param event2 The second WeekViewEvent.
+     * @return True if the objects represent the same event.
+     */
+    private boolean eventsEqual(WeekViewEvent event1, WeekViewEvent event2) {
+        return (event1.getStartTime() == event2.getStartTime())
+            && (event1.getEndTime() == event2.getEndTime())
+            && (event1.getName() == event2.getName())
+            && (event1.getId() == event2.getId());
+    }
+
+    /**
      * Add a new task to the weekly view
      * @param title
      * @param startTime
@@ -216,8 +231,13 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
     }
 
     public void deleteTask(WeekViewEvent event) {
-        Toast.makeText(this, "TODO: remove event " + event.getName(), Toast.LENGTH_SHORT).show();
-        mEvents.remove(mEvents.indexOf(event));
+        ArrayList<WeekViewEvent> UpdatedList = new ArrayList<WeekViewEvent>();
+        for(WeekViewEvent e: mEvents) {
+            if(!eventsEqual(e, event)) {
+                UpdatedList.add(e);
+            }
+        }
+        mEvents = UpdatedList;
         mWeekView.notifyDatasetChanged();
     }
 }

--- a/app/src/main/java/com/example/lambda/lambdaorganizer/ScheduleOverview.java
+++ b/app/src/main/java/com/example/lambda/lambdaorganizer/ScheduleOverview.java
@@ -204,8 +204,7 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
 
         mEvents.add(event);
 
-        // refresh week view. Not good if events added to a day other than today
-        mWeekView.goToToday();
+        mWeekView.notifyDatasetChanged();
     }
 
     /**
@@ -219,6 +218,6 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
     public void deleteTask(WeekViewEvent event) {
         Toast.makeText(this, "TODO: remove event " + event.getName(), Toast.LENGTH_SHORT).show();
         mEvents.remove(mEvents.indexOf(event));
-        mWeekView.goToToday();
+        mWeekView.notifyDatasetChanged();
     }
 }

--- a/app/src/main/java/com/example/lambda/lambdaorganizer/ScheduleOverview.java
+++ b/app/src/main/java/com/example/lambda/lambdaorganizer/ScheduleOverview.java
@@ -30,9 +30,9 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
         WeekView.EventLongPressListener{
 
     private static final int TYPE_DAY_VIEW = 1;
-    private static final int TYPE_THREE_DAY_VIEW = 2;
-    private static final int TYPE_WEEK_VIEW = 3;
-    private int mWeekViewType = TYPE_WEEK_VIEW;
+    private static final int TYPE_THREE_DAY_VIEW = 3;
+    private static final int TYPE_WEEK_VIEW = 7;
+    private int mWeekViewType = TYPE_THREE_DAY_VIEW;
     private WeekView mWeekView;
     private List<WeekViewEvent> mEvents;
     protected SimpleDateFormat dateFormatter = new SimpleDateFormat("dd MMM yyyy");
@@ -59,6 +59,8 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
         mWeekView.setOnEventClickListener(this);
         mWeekView.setEmptyViewClickListener(this);
         mWeekView.setEventLongPressListener(this);
+
+        mWeekView.setNumberOfVisibleDays(mWeekViewType);
 
         ///////////////////////
         // Set up Month View //
@@ -180,8 +182,14 @@ public class ScheduleOverview extends AppCompatActivity implements WeekView.Even
     @Override
     public List<? extends WeekViewEvent> onMonthChange(int newYear, int newMonth) {
         // Populate the week view with some events.
-
-        return mEvents;
+        // Work around Week view library adding the events 3 times
+        ArrayList<WeekViewEvent> eventsMonth = new ArrayList<WeekViewEvent>();
+        for (int i = 0; i < mEvents.size(); i++) {
+            if (mEvents.get(i).getStartTime().get(Calendar.MONTH) == newMonth) {
+                eventsMonth.add(mEvents.get(i));
+            }
+        }
+        return eventsMonth;
     }
 
     /**


### PR DESCRIPTION
Fixed a few bugs in the weekly view for the scheduler.
- Adding and removing tasks no longer jumps to the current day.
- Event title is displayed once instead of three times.
- Deleting events removes the one you actually pressed instead of the first one you added.